### PR TITLE
Make 'gmaven.bzl' file generating more faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bazel-*
+/*.class


### PR DESCRIPTION
Tested on my MacBook (2.4 GHz Intel Core i5), from 9 mins to about 3 mins.

On master branch: 
```
$ time ( java GMavenToBazel; ) 
( java GMavenToBazel; )  13.94s user 1.71s system 2% cpu 9:37.83 total
```

Checkout the requested branch:
```
$ time ( java GMavenToBazel; ) 
( java GMavenToBazel; )  15.96s user 1.55s system 10% cpu 2:43.81 total
```

